### PR TITLE
Add a better exception message for curved geometries

### DIFF
--- a/src/NetTopologySuite.IO.SqlServerBytes/Properties/Resources.Designer.cs
+++ b/src/NetTopologySuite.IO.SqlServerBytes/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NetTopologySuite.IO.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -120,6 +120,15 @@ namespace NetTopologySuite.IO.Properties {
         internal static string UnexpectedOgcGeometryType {
             get {
                 return ResourceManager.GetString("UnexpectedOgcGeometryType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported type: {0}. Geometries containing circular arc segments aren&apos;t supported. Consider using the STCurveToLine function in SQL to return a polygonal approximation instead..
+        /// </summary>
+        internal static string UnsupportedCurvedGeographyType {
+            get {
+                return ResourceManager.GetString("UnsupportedCurvedGeographyType", resourceCulture);
             }
         }
     }

--- a/src/NetTopologySuite.IO.SqlServerBytes/Properties/Resources.resx
+++ b/src/NetTopologySuite.IO.SqlServerBytes/Properties/Resources.resx
@@ -138,4 +138,7 @@
   <data name="UnexpectedOgcGeometryType" xml:space="preserve">
     <value>Unsupported type: {0}</value>
   </data>
+  <data name="UnsupportedCurvedGeographyType" xml:space="preserve">
+    <value>Unsupported type: {0}. Geometries containing circular arc segments aren't supported. Consider using STCurveToLine in SQL to return a polygonal approximation instead.</value>
+  </data>
 </root>

--- a/src/NetTopologySuite.IO.SqlServerBytes/SqlServerBytesReader.cs
+++ b/src/NetTopologySuite.IO.SqlServerBytes/SqlServerBytesReader.cs
@@ -241,6 +241,11 @@ namespace NetTopologySuite.IO
                         geometries.Remove(shapeIndex);
                         break;
 
+                    case OpenGisType.CircularString:
+                    case OpenGisType.CompoundCurve:
+                    case OpenGisType.CurvePolygon:
+                        throw new ParseException(string.Format(Resources.UnsupportedCurvedGeographyType, shape.Type));
+
                     default:
                         throw new ParseException(string.Format(Resources.UnexpectedGeographyType, shape.Type));
                 }

--- a/test/NetTopologySuite.IO.SqlServerBytes.Test/SqlServerBytesReaderTest.cs
+++ b/test/NetTopologySuite.IO.SqlServerBytes.Test/SqlServerBytesReaderTest.cs
@@ -167,7 +167,7 @@ namespace NetTopologySuite.IO
             var ex = Assert.Throws<ParseException>(
                 () => Read("0000000002040300000000000000000000000000000000000000000000000000F03F000000000000F03F0000000000000040000000000000000001000000020000000001000000FFFFFFFF0000000008"));
 
-            Assert.Equal(string.Format(Resources.UnexpectedGeographyType, "CircularString"), ex.Message);
+            Assert.Equal(string.Format(Resources.UnsupportedCurvedGeographyType, "CircularString"), ex.Message);
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace NetTopologySuite.IO
             var ex = Assert.Throws<ParseException>(
                 () => Read("0000000002040400000000000000000000000000000000000000000000000000F03F00000000000000000000000000000040000000000000F03F0000000000000840000000000000000001000000030000000001000000FFFFFFFF0000000009020000000203"));
 
-            Assert.Equal(string.Format(Resources.UnexpectedGeographyType, "CompoundCurve"), ex.Message);
+            Assert.Equal(string.Format(Resources.UnsupportedCurvedGeographyType, "CompoundCurve"), ex.Message);
         }
 
         [Fact]
@@ -185,7 +185,7 @@ namespace NetTopologySuite.IO
             var ex = Assert.Throws<ParseException>(
                 () => Read("000000000204050000000000000000000040000000000000F03F000000000000F03F00000000000000400000000000000000000000000000F03F000000000000F03F00000000000000000000000000000040000000000000F03F01000000020000000001000000FFFFFFFF000000000A"));
 
-            Assert.Equal(string.Format(Resources.UnexpectedGeographyType, "CurvePolygon"), ex.Message);
+            Assert.Equal(string.Format(Resources.UnsupportedCurvedGeographyType, "CurvePolygon"), ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Note, we're also adding EF.Functions.CurveToLine in EF7 for LINQ. (PR https://github.com/dotnet/efcore/pull/28118)